### PR TITLE
fixedConfirmationEmailPaypal

### DIFF
--- a/src/main/java/com/CommuVerse/CommuVerse_api/service/impl/CheckoutServiceImpl.java
+++ b/src/main/java/com/CommuVerse/CommuVerse_api/service/impl/CheckoutServiceImpl.java
@@ -83,7 +83,7 @@ public class CheckoutServiceImpl implements CheckoutService {
         model.put("endDate", formattedEndDate);
 
        Mail mail = emailService.createMail(
-                userEmail,
+                subscription.getUser().getEmail(),
                 "Confirmación de Pago de Suscripción",
                 model,
                 mailFrom


### PR DESCRIPTION
Se corrigió un error que no permitía el enviar correos para la confimación de Paypal.